### PR TITLE
bugfix: ifPresent callback exe conditon

### DIFF
--- a/py_nullable/nullable.py
+++ b/py_nullable/nullable.py
@@ -220,7 +220,7 @@ class Nullable(Generic[T]):
             some string
         """
         value: Optional[T] = self.__value
-        if value is None:
+        if value is not None:
             if not isinstance(action, Callable):
                 raise UncallableException(callback=action)
             try:


### PR DESCRIPTION
BugFix: Nullable#ifPresent
The condition that should have been `value is not None` was `value is None`.